### PR TITLE
Proposed change to [copy]

### DIFF
--- a/lib/impl_SDCZ.ml
+++ b/lib/impl_SDCZ.ml
@@ -98,11 +98,11 @@ let copy ?n ?ofsy ?incy ?y ?ofsx ?incx x =
   let ofsx, incx = get_vec_geom loc x_str ofsx incx in
   let ofsy, incy = get_vec_geom loc y_str ofsy incy in
   let n = get_dim_vec loc x_str ofsx incx x n_str n in
-  let y, ofsy, incy =
+  let y =
     let min_dim_y = ofsy + (n - 1) * abs incy in
     match y with
-    | Some y -> check_vec loc y_str y min_dim_y; y, ofsy, incy
-    | None -> Vec.create min_dim_y, 1, 1 in
+    | Some y -> check_vec loc y_str y min_dim_y; y
+    | None -> Vec.create min_dim_y in
   direct_copy ~n ~ofsy ~incy ~y ~ofsx ~incx ~x;
   y
 


### PR DESCRIPTION
Briefly, the issue is that if I call [Lacaml.Impl.D.copy ~ofsy:2 x], and x has length n, it will (correctly) create a vector of length n + 1, but (incorrectly, I think) copy into it starting at index 1 rather than index 2.

More precisely, if [y] is not passed as an argument to [copy]  (i.e., [y=None]), the values of [incy] and [ofsy] are obeyed for the purposes of computing how long the resulting vector should be, but are then set to 1 before doing the actual copy.

I think the fix is simply not to rebind [ofsy] and [incy] to 1 when [y=None].