### PR TITLE
Enabled POSIX.1-2001 for use of `struct timespec' and `nanosleep'

### DIFF
--- a/lib/utils_c.c
+++ b/lib/utils_c.c
@@ -21,6 +21,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+// Enable POSIX.1-2001 for use of `struct timespec' and `nanosleep'
+#define _POSIX_C_SOURCE 200112L
+
 #include "utils_c.h"
 #include <caml/alloc.h>
 


### PR DESCRIPTION
I tried manual build of Lacaml 7.2.3 on Debian 7.8, OCaml 4.02.1 and gcc 4.7.2 but failed.
`lib/utils_c.c` cannot be compiled with option `-std=c99` because `struct timespec` and
`nanosleep` are NOT supported by ISO C99 (cf. http://linux.die.net/man/2/nanosleep).
For use of them, I enabled POSIX.1-2001 by `#define _POSIX_C_SOURCE 200112L`
(cf. http://linux.die.net/man/7/feature_test_macros).

    $ uname -a
    Linux pc5 3.2.0-4-686-pae #1 SMP Debian 3.2.65-1+deb7u1 i686 GNU/Linux
    $ cat /etc/debian_version 
    7.8
    $ ocaml -version
    The OCaml toplevel, version 4.02.1
    $ gcc --version
    gcc (Debian 4.7.2-5) 4.7.2
    Copyright (C) 2012 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
    $ make
    ocaml setup.ml -build 
    /home/akinori/.opam/4.02.1/bin/ocamlopt.opt unix.cmxa -I /home/akinori/.opam/4.02.1/lib/ocaml/ocamlbuild /home/akinori/.opam/4.02.1/lib/ocaml/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/akinori/.opam/4.02.1/lib/ocaml/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
    /home/akinori/.opam/4.02.1/bin/ocamlfind ocamlc -ccopt -g -ccopt '-std=c99' -ccopt -O2 -ccopt -fPIC -ccopt -DPIC -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/impl_c.c
    mv impl_c.o lib/impl_c.o
    /home/akinori/.opam/4.02.1/bin/ocamlfind ocamlc -ccopt -g -ccopt '-std=c99' -ccopt -O2 -ccopt -fPIC -ccopt -DPIC -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/utils_c.c
    + /home/akinori/.opam/4.02.1/bin/ocamlfind ocamlc -ccopt -g -ccopt '-std=c99' -ccopt -O2 -ccopt -fPIC -ccopt -DPIC -ccopt -Wall -ccopt -pedantic -ccopt -Wextra -ccopt -Wunused -ccopt -Wno-long-long -c lib/utils_c.c
    lib/utils_c.c: In function ‘portable_sleep’:
    lib/utils_c.c:47:19: error: storage size of ‘tim’ isn’t known
    lib/utils_c.c:47:24: error: storage size of ‘tim2’ isn’t known
    lib/utils_c.c:51:3: warning: implicit declaration of function ‘nanosleep’ [-Wimplicit-function-declaration]
    lib/utils_c.c:47:24: warning: unused variable ‘tim2’ [-Wunused-variable]
    lib/utils_c.c:47:19: warning: unused variable ‘tim’ [-Wunused-variable]
    lib/utils_c.c:53:1: warning: control reaches end of non-void function [-Wreturn-type]