### PR TITLE
Fixed computation of Lacaml.[CZ].Vec.ssqr_diff

### DIFF
--- a/lib/vec_CZ_c.c
+++ b/lib/vec_CZ_c.c
@@ -353,8 +353,8 @@ CAMLprim value LFUN(ssqr_stub)(
 #define FUNC(acc, x, y) \
   x.r -= y.r; \
   x.i -= y.i; \
-  acc.r += x.r*x.r - y.i*y.i; \
-  acc.i += x.r*y.i + x.i*y.r
+  acc.r += x.r*x.r - x.i*x.i; \
+  acc.i += 2*x.r*x.i
 #include "fold2_col.c"
 
 /* Since executing the (small) callback may dominate the running time,


### PR DESCRIPTION
I tried `Lacaml.C.Vec.ssqr_diff x x` where `x = Lacaml.C.Vec.of_list [{re=1.0; im=1.0}]`, but the result was NOT `{re=0.0; im=0.0}`. `ssqr_diff` should compute the sum of (a[k] - b[k])^2 = (a[k].re-b[k].re)^2 - (a[k].im-b[k].im)^2 + 2 i (a[k].re-b[k].re) (a[k].im-b[k].im). In `ssqr_diff_stub` of `vec_CZ_c.c`, `x.r` = a[k].re - b[k].re, and `x.i` = a[k].im - b[k].im, thus the real part and the imaginary part should be `x.r*x.r - x.i*x.i` and `2*x.r*x.i`, respectively. I fixed the computation of `ssqr_diff_stub`.