### PR TITLE
Add mat of col lists

### DIFF
--- a/lib/mat_SDCZ.ml
+++ b/lib/mat_SDCZ.ml
@@ -158,6 +158,33 @@ let to_col_vecs mat =
     for i = 2 to n do ar.(i - 1) <- col mat i done;
     ar
 
+let of_col_vecs_list = function
+  | []  -> create 0 0
+  | (h :: _) as lst ->
+    let n = List.length lst in
+    let m = Array1.dim h in
+    let mat = create m n in
+    let rec loop i = function
+      | [] -> mat
+      | h :: t ->
+        if Array1.dim h <> m then
+          failwith "of_col_vecs_list: vectors not of same length";
+        direct_copy ~n:m ~ofsy:1 ~incy:1 ~y:(col mat i) ~ofsx:1 ~incx:1 ~x:h;
+        loop (i + 1) t
+    in
+    loop 1 lst
+
+let to_col_vecs_list mat =
+  let n = dim2 mat in
+  if n = 0 then []
+  else
+    let rec loop i acc =
+      if i < 1 then acc
+      else
+        loop (i - 1) (col mat i :: acc)
+    in
+    loop n []
+
 let as_vec mat =
   let gen = genarray_of_array2 mat in
   reshape_1 gen (dim1 mat * dim2 mat)

--- a/lib/mat_SDCZ.ml
+++ b/lib/mat_SDCZ.ml
@@ -159,7 +159,7 @@ let to_col_vecs mat =
     ar
 
 let of_col_vecs_list = function
-  | []  -> create 0 0
+  | [] -> create 0 0
   | (h :: _) as lst ->
     let n = List.length lst in
     let m = Array1.dim h in
@@ -176,14 +176,41 @@ let of_col_vecs_list = function
 
 let to_col_vecs_list mat =
   let n = dim2 mat in
-  if n = 0 then []
-  else
-    let rec loop i acc =
-      if i < 1 then acc
-      else
-        loop (i - 1) (col mat i :: acc)
+  let rec loop i acc =
+    if i < 1 then acc
+    else
+      loop (i - 1) (col mat i :: acc)
+  in
+  loop n []
+
+let of_list = function
+  | [] -> create 0 0
+  | (h :: _) as lst ->
+    let m = List.length lst in
+    let n = List.length h in
+    let mat = create m n in
+    let rec loop i = function
+      | [] -> mat
+      | h :: t ->
+        List.iteri (fun jm1 e -> mat.{i, jm1+1} <- e) h;
+        loop (i + 1) t
     in
-    loop n []
+    try loop 1 lst
+    with Invalid_argument _ ->
+      failwith "of_list: vectors not of same length"
+
+let to_list mat =
+  let m = dim1 mat in
+  let n = dim2 mat in
+  let row_to_list r =
+    let rec l j a = if j < 1 then a else l (j - 1) (mat.{r,j} :: a) in
+    l n []
+  in
+  let rec loop i acc =
+    if i < 1 then acc
+    else loop (i - 1) (row_to_list i :: acc)
+  in
+  loop m []
 
 let as_vec mat =
   let gen = genarray_of_array2 mat in

--- a/lib/mat_SDCZ.ml
+++ b/lib/mat_SDCZ.ml
@@ -185,22 +185,19 @@ let to_col_vecs_list mat =
 
 let of_list = function
   | [] -> empty
-  | (h :: _) as lst ->
+  | (h :: t) as lst ->
     let m = List.length lst in
     let n = List.length h in
+    List.iter (fun l -> if List.length l <> n then
+      failwith "of_list: vectors not of same length") t;
     let mat = create m n in
     let rec loop i = function
       | [] -> mat
       | h :: t ->
-        let s = List.fold_left (fun j e -> mat.{i, j} <- e; j + 1) 1 h in
-        if s <= n then
-          invalid_arg "list not long enough"
-        else
-          loop (i + 1) t
+        List.iteri (fun j e -> mat.{i, j + 1} <- e) h;
+        loop (i + 1) t
     in
-    try loop 1 lst
-    with Invalid_argument _ ->
-      failwith "of_list: vectors not of same length"
+    loop 1 lst
 
 let to_list mat =
   let m = dim1 mat in

--- a/lib/mat_SDCZ.ml
+++ b/lib/mat_SDCZ.ml
@@ -159,17 +159,17 @@ let to_col_vecs mat =
     ar
 
 let of_col_vecs_list = function
-  | [] -> create 0 0
-  | (h :: _) as lst ->
+  | [] -> empty
+  | (vec :: _) as lst ->
     let n = List.length lst in
-    let m = Array1.dim h in
+    let m = Array1.dim vec in
     let mat = create m n in
     let rec loop i = function
       | [] -> mat
-      | h :: t ->
-        if Array1.dim h <> m then
+      | vec :: t ->
+        if Array1.dim vec <> m then
           failwith "of_col_vecs_list: vectors not of same length";
-        direct_copy ~n:m ~ofsy:1 ~incy:1 ~y:(col mat i) ~ofsx:1 ~incx:1 ~x:h;
+        direct_copy ~n:m ~ofsy:1 ~incy:1 ~y:(col mat i) ~ofsx:1 ~incx:1 ~x:vec;
         loop (i + 1) t
     in
     loop 1 lst
@@ -184,7 +184,7 @@ let to_col_vecs_list mat =
   loop n []
 
 let of_list = function
-  | [] -> create 0 0
+  | [] -> empty
   | (h :: _) as lst ->
     let m = List.length lst in
     let n = List.length h in
@@ -192,8 +192,11 @@ let of_list = function
     let rec loop i = function
       | [] -> mat
       | h :: t ->
-        List.iteri (fun jm1 e -> mat.{i, jm1+1} <- e) h;
-        loop (i + 1) t
+        let s = List.fold_left (fun j e -> mat.{i, j} <- e; j + 1) 1 h in
+        if s <= n then
+          invalid_arg "list not long enough"
+        else
+          loop (i + 1) t
     in
     try loop 1 lst
     with Invalid_argument _ ->

--- a/lib/mat_SDCZ.mli
+++ b/lib/mat_SDCZ.mli
@@ -53,13 +53,14 @@ val to_array : mat -> num_type array array
     [mat]. *)
 
 val of_list : num_type list list -> mat
-(** [of_list ar] @return a matrix initialized from the list of lists
-    [ar]. It is assumed that the OCaml matrix is in row major order
-    (standard). *)
+(** [of_list ls] @return a matrix initialized from the list of lists
+    [ls]. Each sublist of [ls] represents a row of the desired matrix,
+    and must be of the same length.
+
+    @raise Invalid_argument if sublists are not of the same length.*)
 
 val to_list : mat -> num_type list list
-(** [to_array mat] @return a list of lists initialized from matrix
-    [mat]. *)
+(** [to_array mat] @return [mat] in row major order as lists. *)
 
 val of_col_vecs : vec array -> mat
 (** [of_col_vecs ar] @return a matrix whose columns are initialized from

--- a/lib/mat_SDCZ.mli
+++ b/lib/mat_SDCZ.mli
@@ -60,6 +60,14 @@ val to_col_vecs : mat -> vec array
 (** [to_col_vecs mat] @return an array of column vectors initialized
     from matrix [mat]. *)
 
+val of_col_vecs_list : vec list -> mat
+(** [of_col_vecs_list ar] @return a matrix whose columns are initialized from
+    the list of vectors [ar].  The vectors must be of same length. *)
+
+val to_col_vecs_list : mat -> vec list
+(** [to_col_vecs_list mat] @return a list of column vectors initialized
+    from matrix [mat]. *)
+
 val as_vec : mat -> vec
 (** [as_vec mat] @return a vector containing all elements of the
     matrix in column-major order.  The data is shared. *)

--- a/lib/mat_SDCZ.mli
+++ b/lib/mat_SDCZ.mli
@@ -52,6 +52,15 @@ val to_array : mat -> num_type array array
 (** [to_array mat] @return an array of arrays initialized from matrix
     [mat]. *)
 
+val of_list : num_type list list -> mat
+(** [of_list ar] @return a matrix initialized from the list of lists
+    [ar]. It is assumed that the OCaml matrix is in row major order
+    (standard). *)
+
+val to_list : mat -> num_type list list
+(** [to_array mat] @return a list of lists initialized from matrix
+    [mat]. *)
+
 val of_col_vecs : vec array -> mat
 (** [of_col_vecs ar] @return a matrix whose columns are initialized from
     the array of vectors [ar].  The vectors must be of same length. *)
@@ -62,7 +71,7 @@ val to_col_vecs : mat -> vec array
 
 val of_col_vecs_list : vec list -> mat
 (** [of_col_vecs_list ar] @return a matrix whose columns are initialized from
-    the list of vectors [ar].  The vectors must be of same length. *)
+    the list of vectors [ar]. The vectors must be of same length. *)
 
 val to_col_vecs_list : mat -> vec list
 (** [to_col_vecs_list mat] @return a list of column vectors initialized


### PR DESCRIPTION
This address #2. Note that these methods fail like their array counterparts for matrices off odd sizes such as (0,1) or (1,0).