### PR TITLE
Add exp1m and log1p to build in functions for vectors

### DIFF
--- a/lib/vec_SD.ml
+++ b/lib/vec_SD.ml
@@ -103,6 +103,26 @@ let exp ?n ?ofsy ?incy ?y ?ofsx ?incx x =
   direct_exp ~n ~ofsy ~incy ~y ~ofsx ~incx ~x;
   y
 
+external direct_expm1 :
+  n : int ->
+  ofsy : int ->
+  incy : int ->
+  y : vec ->
+  ofsx : int ->
+  incx : int ->
+  x : vec ->
+  unit = "lacaml_FPRECexpm1_stub_bc" "lacaml_FPRECexpm1_stub"
+
+let vec_exp1m_loc = "Vec.expm1"
+
+let expm1 ?n ?ofsy ?incy ?y ?ofsx ?incx x =
+  let ofsx, incx = get_vec_geom vec_exp1m_loc x_str ofsx incx in
+  let ofsy, incy = get_vec_geom vec_exp1m_loc y_str ofsy incy in
+  let n = get_dim_vec vec_exp1m_loc x_str ofsx incx x n_str n in
+  let y = get_y_vec ~loc:vec_exp1m_loc ~ofsy ~incy ~n y in
+  direct_expm1 ~n ~ofsy ~incy ~y ~ofsx ~incx ~x;
+  y
+
 external direct_log :
   n : int ->
   ofsy : int ->
@@ -121,6 +141,26 @@ let log ?n ?ofsy ?incy ?y ?ofsx ?incx x =
   let n = get_dim_vec vec_log_loc x_str ofsx incx x n_str n in
   let y = get_y_vec ~loc:vec_log_loc ~ofsy ~incy ~n y in
   direct_log ~n ~ofsy ~incy ~y ~ofsx ~incx ~x;
+  y
+
+external direct_log1p :
+  n : int ->
+  ofsy : int ->
+  incy : int ->
+  y : vec ->
+  ofsx : int ->
+  incx : int ->
+  x : vec ->
+  unit = "lacaml_FPREClog1p_stub_bc" "lacaml_FPREClog1p_stub"
+
+let vec_log1p_loc = "Vec.log1p"
+
+let log1p ?n ?ofsy ?incy ?y ?ofsx ?incx x =
+  let ofsx, incx = get_vec_geom vec_log1p_loc x_str ofsx incx in
+  let ofsy, incy = get_vec_geom vec_log1p_loc y_str ofsy incy in
+  let n = get_dim_vec vec_log1p_loc x_str ofsx incx x n_str n in
+  let y = get_y_vec ~loc:vec_log1p_loc ~ofsy ~incy ~n y in
+  direct_log1p ~n ~ofsy ~incy ~y ~ofsx ~incx ~x;
   y
 
 external direct_sin :

--- a/lib/vec_SD.mli
+++ b/lib/vec_SD.mli
@@ -114,6 +114,29 @@ val exp :
     @param incx default = 1
 *)
 
+val expm1 :
+  ?n : int ->
+  ?ofsy : int ->
+  ?incy : int ->
+  ?y : vec ->
+  ?ofsx : int ->
+  ?incx : int ->
+  vec
+  -> vec
+(** [expm1 ?n ?ofsy ?incy ?y ?ofsx ?incx x] computes the exponential
+    minus 1 of [n] elements of the vector [x] using [incx] as incremental
+    steps.   If [y] is given, the result will be stored in there
+    using increments of [incy], otherwise a fresh vector will be
+    used.  The resulting vector is returned.
+
+    @param n default = greater n s.t. [ofsx+(n-1)(abs incx) <= dim x]
+    @param ofsy default = 1
+    @param incy default = 1
+    @param y default = fresh vector with [ofsy+(n - 1)(abs incy)] rows
+    @param ofsx default = 1
+    @param incx default = 1
+*)
+
 val log :
   ?n : int ->
   ?ofsy : int ->
@@ -125,6 +148,29 @@ val log :
   -> vec
 (** [log ?n ?ofsy ?incy ?y ?ofsx ?incx x] computes the logarithm
     of [n] elements of the vector [x] using [incx] as incremental
+    steps.   If [y] is given, the result will be stored in there
+    using increments of [incy], otherwise a fresh vector will be
+    used.  The resulting vector is returned.
+
+    @param n default = greater n s.t. [ofsx+(n-1)(abs incx) <= dim x]
+    @param ofsy default = 1
+    @param incy default = 1
+    @param y default = fresh vector with [ofsy+(n - 1)(abs incy)] rows
+    @param ofsx default = 1
+    @param incx default = 1
+*)
+
+val log1p :
+  ?n : int ->
+  ?ofsy : int ->
+  ?incy : int ->
+  ?y : vec ->
+  ?ofsx : int ->
+  ?incx : int ->
+  vec
+  -> vec
+(** [log1p ?n ?ofsy ?incy ?y ?ofsx ?incx x] computes the logarithm
+    plus 1 of [n] elements of the vector [x] using [incx] as incremental
     steps.   If [y] is given, the result will be stored in there
     using increments of [incy], otherwise a fresh vector will be
     used.  The resulting vector is returned.

--- a/lib/vec_SD_c.c
+++ b/lib/vec_SD_c.c
@@ -213,9 +213,19 @@ CAMLprim value LFUN(ssqr_stub)(
 #define FUNC(dst, x) *dst = exp(x)
 #include "vec_map.c"
 
+#define NAME LFUN(expm1_stub)
+#define BC_NAME LFUN(expm1_stub_bc)
+#define FUNC(dst, x) *dst = expm1(x)
+#include "vec_map.c"
+
 #define NAME LFUN(log_stub)
 #define BC_NAME LFUN(log_stub_bc)
 #define FUNC(dst, x) *dst = log(x)
+#include "vec_map.c"
+
+#define NAME LFUN(log1p_stub)
+#define BC_NAME LFUN(log1p_stub_bc)
+#define FUNC(dst, x) *dst = log1p(x)
 #include "vec_map.c"
 
 #define NAME LFUN(sin_stub)


### PR DESCRIPTION
```OCaml
# let e = epsilon_float /. 10. ;;
val e : float = 2.2204460492503132e-17
# Printf.printf "%0.20f" (Vec.log1p (Vec.make 2 e)).{1} ;;
0.00000000000000002220- : unit = ()
# Printf.printf "%0.20f" (Vec.log (Vec.make 2 (1. +. e))).{1} ;;
0.00000000000000000000-
```

