### PR TITLE
fix compiler flags for mingw64

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -80,9 +80,9 @@ Library lacaml
   if system(macosx)
     CCOpt+:      -DEXTERNAL_EXP10
     CCLib:       -framework Accelerate
-  # FIXME: mingw is untested!!!
-  if system(mingw)
-    CCOpt+:      -DEXTERNAL_EXP10
+  # building on Windows is only tested for mingw64 toolchain
+  if system(mingw64)
+    CCOpt+:      -DEXTERNAL_EXP10 -DWIN32
 
 Library lacaml_top
   Path:             lib


### PR DESCRIPTION
mingw64 does not support `nanosleep()`, so we have to take `Sleep()` from the win-api (include windows.h via -DWIN32).
Currently the dependencies conf-blas & conf-lapack don't build on my cygwin/mingw64 box, but a fix should be easy...
I did not include `setup.ml`, `configure`, etc. in this PR, as on windows `oasis setup` introduces some backslashes in pathnames, which most probably breaks building on Linux.