### PR TITLE
fix exp10 error on FreeBSD

### DIFF
--- a/lib/vec_CZ_c.c
+++ b/lib/vec_CZ_c.c
@@ -57,7 +57,13 @@ CAMLprim value LFUN(linspace_stub)(value vY, value va, value vb, value vN)
 
 extern double exp(double);
 extern double exp2(double);
-extern double exp10(double);
+#ifdef __FreeBSD__
+static double exp10(double x){
+  return exp(log(10)*x);
+}
+#else
+extern double exp10(double x);
+#endif
 
 CAMLprim value LFUN(logspace_stub)(value vY, value va, value vb,
                                    value vbase, value vN)

--- a/lib/vec_SD_c.c
+++ b/lib/vec_SD_c.c
@@ -50,7 +50,13 @@ CAMLprim value LFUN(linspace_stub)(value vY, value va, value vb, value vN)
   CAMLreturn(Val_unit);
 }
 
-extern double exp10(double);
+#ifdef __FreeBSD__
+static double exp10(double x){
+	  return exp(log(10)*x);
+}
+#else
+extern double exp10(double x);
+#endif
 
 CAMLprim value LFUN(logspace_stub)(value vY, value va, value vb,
                                    value vbase, value vN)


### PR DESCRIPTION
There is no exp10 function in FreeBSD standard library, workaround needed.