### PR TITLE
explicitly link libm in jbuild spec

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -41,7 +41,11 @@
     ; NOTE: for debugging before releases
     ; -Wall -pedantic -Wextra -Wunused
   ))
-  (c_library_flags (:include c_library_flags.sexp))
+  (c_library_flags (
+    (:include c_library_flags.sexp)
+    -lm
+  ))
+
   (libraries (bigarray))
 ))
 


### PR DESCRIPTION
This PR adds `-lm` to the c library flags in the `src/jbuild` file which eliminates the following error for me when loading `lacaml` in utop.

```
Cannot load required shared library dlllacaml_stubs.
Reason: /home/.../.opam/4.06.0/lib/stublibs/dlllacaml_stubs.so:
/home/.../.opam/4.06.0/lib/stublibs/dlllacaml_stubs.so: undefined symbol: _ZGVdN8vv___powf_finite.
```

