### PR TITLE
Add warning flags to dev profile

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,5 @@
 (env
-  (dev (flags (:standard -w -9 -principal)))
-  (release (ocamlopt_flags (:standard -O3)))
-)
+  (dev
+   (flags (:standard -w -9 -principal))
+   (c_flags (:standard -Wall -pedantic -Wextra -Wunused)))
+  (release (ocamlopt_flags (:standard -O3))))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.1)
+(lang dune 1.7)
 (name lacaml)

--- a/lacaml.opam
+++ b/lacaml.opam
@@ -28,7 +28,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05"}
-  "dune" {build & >= "1.4.0"}
+  "dune" {build & >= "1.7.0"}
   "conf-blas" {build}
   "conf-lapack" {build}
   "base" {build}

--- a/src/config/dune
+++ b/src/config/dune
@@ -27,8 +27,6 @@
     ; safe with the current Lacaml code base
     -O3 -march=native -ffast-math
     -fPIC -DPIC
-    ; NOTE: for debugging before releases
-    ; -Wall -pedantic -Wextra -Wunused
   )
   (c_library_flags (:include c_library_flags.sexp) -lm)
   (libraries base)

--- a/src/dune
+++ b/src/dune
@@ -32,8 +32,6 @@
     ; safe with the current Lacaml code base
     -O3 -march=native -ffast-math
     -fPIC -DPIC
-    ; NOTE: for debugging before releases
-    ; -Wall -pedantic -Wextra -Wunused
   )
   (c_library_flags (:include config/c_library_flags.sexp) -lm)
 


### PR DESCRIPTION
Previously, we'd rely on uncommenting the flags out. Using the profile
dependent env stanza gives this automatically. This feature is only
available since dune 1.7 so constraints must be bumped accordingly.