### PR TITLE
Fix a build-system race condition

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -81,6 +81,7 @@
     impl_SDCZ.mli impl_SDCZ.ml impl_SD.mli impl_SD.ml impl_CZ.mli impl_CZ.ml
     mat_SDCZ.mli mat_SDCZ.ml mat_SD.mli mat_SD.ml mat_CZ.mli mat_CZ.ml
     vec_SDCZ.mli vec_SDCZ.ml vec_SD.mli vec_SD.ml vec_CZ.mli vec_CZ.ml
+    real_io.mli complex_io.mli
   )
   (action (run config/make_prec_dep.exe))
 )


### PR DESCRIPTION
While building lacaml on a fast server with dune cache enabled I uncovered an issue: the build failed with the following error message:
```
- make_prec_dep src/C.{ml,mli},src/D.{ml,mli},src/S.{ml,mli},src/Z.{ml,mli},src/impl2_C.{ml,mli},src/impl2_D.{ml,mli},src/impl2_S.{ml,mli},src/impl2_Z.{ml,mli},src/impl4_C.{ml,mli},src/impl4_D.{ml,mli},src/impl4_S.{ml,mli},src/impl4_Z.{ml,mli},src/lacaml.mli,src/mat2_C.{ml,mli},src/mat2_D.{ml,mli},src/mat2_S.{ml,mli},src/mat2_Z.{ml,mli},src/mat4_C.{ml,mli},src/mat4_D.{ml,mli},src/mat4_S.{ml,mli},src/mat4_Z.{ml,mli},src/vec2_C.{ml,mli},src/vec2_D.{ml,mli},src/vec2_S.{ml,mli},src/vec2_Z.{ml,mli},src/vec4_C.{ml,mli},src/vec4_D.{ml,mli},src/vec4_S.{ml,mli},src/vec4_Z.{ml,mli} (exit 2)
- (cd _build/default/src && config/make_prec_dep.exe)
- Fatal error: exception (Failure
-   "Trying to replace \"include module type of Real_io\" but the file \"real_io.mli\" does not exist")
- Raised at file "stdlib.ml", line 29, characters 17-33
- Called from file "str.ml", line 679, characters 26-39
- Called from file "str.ml", line 683, characters 31-51
- Called from file "src/config/make_prec_dep.ml", line 107, characters 10-46
- Called from file "list.ml", line 110, characters 12-15
- Called from file "array.ml", line 95, characters 31-48
- Called from file "src/config/make_prec_dep.ml" (inlined), line 163, characters 4-46
- Called from file "src/config/make_prec_dep.ml", line 254, characters 2-130
```
Apparently `real_io.mli` and `complex_io.mli` are dependencies of the "make_prec_deps" rule but were usually copied before the execution of the command so this error was never encountered before.

This issue can be made apparent using `dune build --sandbox=copy` (requires dune >= 2.0) for instance.