### PR TITLE
Removed dependencies to Stdio and Base to enable ocaml-multicore compatibility

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,8 +38,6 @@ convenience functions for vectors and matrices.")
     dune-configurator
     (conf-blas :build)
     (conf-lapack :build)
-    (base :build)
-    (stdio :build)
     base-bytes
     base-bigarray
   )

--- a/lacaml.opam
+++ b/lacaml.opam
@@ -37,8 +37,6 @@ depends: [
   "dune-configurator"
   "conf-blas" {build}
   "conf-lapack" {build}
-  "base" {build}
-  "stdio" {build}
   "base-bytes"
   "base-bigarray"
 ]

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,6 +1,9 @@
-open Base
+let split_ws str = String.(split_on_char ' ' str |> List.filter ((<>) ""))
 
-let split_ws str = String.(split str ~on:' ' |> List.filter ~f:((<>) ""))
+let option_value_map ~default ~f x = 
+  match x with 
+  | Some x -> f x
+  | None -> default
 
 let () =
   let module C = Configurator.V1 in
@@ -22,12 +25,13 @@ let () =
          using the GNU compiler. *)
       let default =
         { cflags = "-DEXTERNAL_EXP10" :: "-std=c99" :: cflags; libs } in
-      Option.value_map (C.ocaml_config_var c "system") ~default ~f:(function
+      option_value_map (C.ocaml_config_var c "system") ~default ~f:(function
         | "linux" | "linux_elf" -> { cflags = "-std=gnu99" :: cflags; libs }
         | "macosx" when not libs_override ->
             { default with libs = "-framework" :: "Accelerate" :: libs }
         | "mingw64" -> { cflags = "-DWIN32" :: default.cflags; libs }
         | _ -> default)
+        
     in
     C.Flags.write_sexp "c_flags.sexp" conf.cflags;
     C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -10,12 +10,12 @@ let () =
   let open C.Pkg_config in
   C.main ~name:"lacaml" (fun c ->
     let cflags =
-      match Caml.Sys.getenv_opt "LACAML_CFLAGS" with
+      match Sys.getenv_opt "LACAML_CFLAGS" with
       | Some alt_cflags -> split_ws alt_cflags
       | None -> []
     in
     let libs, libs_override =
-      match Caml.Sys.getenv_opt "LACAML_LIBS" with
+      match Sys.getenv_opt "LACAML_LIBS" with
       | Some alt_libs -> split_ws alt_libs, true
       | None -> ["-lblas"; "-llapack"], false
     in

--- a/src/config/dune
+++ b/src/config/dune
@@ -1,13 +1,13 @@
 (executable
   (name discover)
   (modules discover)
-  (libraries base dune.configurator)
+  (libraries dune.configurator)
 )
 
 (executable
   (name make_prec_dep)
   (modules make_prec_dep)
-  (libraries base stdio str)
+  (libraries str)
 )
 
 (rule
@@ -29,7 +29,6 @@
     -fPIC -DPIC
   )
   (c_library_flags (:include c_library_flags.sexp) -lm)
-  (libraries base)
 )
 
 (executable

--- a/src/config/make_prec_dep.ml
+++ b/src/config/make_prec_dep.ml
@@ -1,7 +1,5 @@
 (* Create precision dependent OCaml files *)
 
-open Base
-open Stdio
 open Printf
 
 module Filename = Caml.Filename
@@ -15,20 +13,27 @@ let src = "."
 let comment_re = Str.regexp "(\\* [^*]+\\*)[ \n\r\t]*"
 
 let input_file ?(path=src) ?(comments=true) ?(prefix="") fname =
-  In_channel.with_file (Filename.concat path fname) ~f:(fun ic ->
-    let buf = Buffer.create 2048 in
-    In_channel.iter_lines ic ~f:(fun l ->
-      if String.(l <> "") then begin
-        Buffer.add_string buf prefix;
-        Buffer.add_string buf l
-      end;
-      Buffer.add_char buf '\n');
+  let fh = open_in (Filename.concat path fname) in
+  let buf = Buffer.create 2048 in
+  try
+    while true do
+      let l = input_line fh in (* or exn *)
+      if l <> "" then (Buffer.add_string buf prefix;
+                      Buffer.add_string buf l );
+      Buffer.add_char buf '\n'
+    done;
+    assert false
+  with _->
+    close_in fh;
     let buf = Buffer.contents buf in
     if comments then buf
-    else Str.global_replace comment_re "" buf)
+    else Str.global_replace comment_re "" buf
+
 
 let output_file ?(path=src) fname ~content =
-  Out_channel.write_all (Filename.concat path fname) ~data:content
+  let fh = open_out (Filename.concat path fname) in
+  output_string fh content;
+  close_out fh
 
 let ocaml_major, ocaml_minor =
   Scanf.sscanf Sys.ocaml_version "%i.%i" (fun v1 v2 -> v1, v2)
@@ -109,7 +114,7 @@ let rec substitute fname0 fname1 ?(full_doc=false) subs =
 
 and substitute_string ~full_doc s subs =
   let s =
-    List.fold_left ~f:(fun l (r,s) -> Str.global_replace r s l) ~init:s subs
+    List.fold_left (fun l (r,s) -> Str.global_replace r s l) s subs
   in
   (* Substitute [module type of] used alone as a sig. *)
   let s =
@@ -119,7 +124,7 @@ and substitute_string ~full_doc s subs =
       let subst s =
         let m = string_of_mod_name ~prefix:"  " ~full_doc
                   (Str.matched_group 1 s) subs in
-        String.concat [": sig\n"; m; "\nend\n"] in
+        String.concat "" [": sig\n"; m; "\nend\n"] in
       Str.global_substitute sig_module_type_of_re subst s
     else s in
   (* Substitute [module type of] if not supported or explicit doc is desired. *)
@@ -132,7 +137,7 @@ and substitute_string ~full_doc s subs =
   )
 
 and string_of_mod_name ~prefix ~full_doc mname subs =
-  let fincl = String.uncapitalize mname ^ ".mli" in
+  let fincl = String.uncapitalize_ascii mname ^ ".mli" in
   try
     let s' = input_file fincl ~comments:false ~prefix in
     substitute_string ~full_doc s' subs
@@ -148,20 +153,20 @@ let derived_files ?full_doc fnames suffix derived =
   let derive fname =
     if Str.string_match re fname 0 then (
       let seed = Str.matched_group 1 fname in
-      if String.(seed <> "lacaml") then (
+      if seed <> "lacaml" then (
         let derive1 (new_suffix, subs) =
           let fname1 = seed ^ new_suffix in
           substitute fname fname1 ?full_doc subs;
         in
-        List.iter ~f:derive1 derived;
+        List.iter derive1 derived;
       )) in
-  Array.iter ~f:derive fnames
+  Array.iter derive fnames
 
 let () =
   let fnames = Caml.Sys.readdir src in
   let derive ?full_doc suffix subs =
     derived_files ?full_doc fnames suffix subs in
-  let r subs = List.map ~f:(fun (r,s) -> (Str.regexp r, s)) subs in
+  let r subs = List.map (fun (r,s) -> (Str.regexp r, s)) subs in
   let num_type n = (Str.regexp "num_type\\( *[^= ]\\)", n ^ "\\1") in
   let num_type_float = num_type "float" in
   let num_type_complex = num_type "Complex.t" in

--- a/src/config/make_prec_dep.ml
+++ b/src/config/make_prec_dep.ml
@@ -2,9 +2,6 @@
 
 open Printf
 
-module Filename = Caml.Filename
-module Scanf = Caml.Scanf
-
 let src = "."
 
 (* Utils
@@ -163,7 +160,7 @@ let derived_files ?full_doc fnames suffix derived =
   Array.iter derive fnames
 
 let () =
-  let fnames = Caml.Sys.readdir src in
+  let fnames = Sys.readdir src in
   let derive ?full_doc suffix subs =
     derived_files ?full_doc fnames suffix subs in
   let r subs = List.map (fun (r,s) -> (Str.regexp r, s)) subs in


### PR DESCRIPTION
Hi,
I wanted to try my program (which uses Lacaml) with multicore-ocaml.
I could not install Lacaml, because it depends on the Base library which is incompatible with the ocaml-multicore compiler.
I checked in your source code, and there were only very few references to Base and Stdio (which requires Base). So I have removed them, based on your old code.

With the current PR, Lacaml can be installed with ocaml-multicore.


I had a bad personal experience using the Jane Street libraries because the API was frequently changing without ensuring backwards-compatibility, and I was always updating my code to adapt to their changes. Last year I took a week to become independent of this library and I felt free again.