### PR TITLE
add support for apple silicon and ppc

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -43,9 +43,11 @@ let () =
       (* -ffast-math can break IEEE754 floating point semantics, but it is likely
          safe with the current Lacaml code base *)
       let default = ["-O3"; "-march=native"; "-ffast-math"; "-fPIC"; "-DPIC"] in
-      Option.value_map (C.ocaml_config_var c "system") ~default ~f:(function
-        | "macosx" when (C.ocaml_config_var c "architecture") = Some "arm64" ->
+      let system = Option.value (C.ocaml_config_var c "system") ~default:"unknown" in
+      let arch = Option.value (C.ocaml_config_var c "architecture") ~default:"unknown" in
+      match system, arch with
+        | "macosx", "arm64" | _, "ppc64" | _, "ppc64le" | _, "unknown" ->
             ["-O3"; "-ffast-math"; "-fPIC"; "-DPIC"]
-        | _ -> default)
+        | _ -> default
     in
     C.Flags.write_sexp "extra_c_flags.sexp" extra_cflags)

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -26,8 +26,7 @@ let () =
       (* [exp10] is a GNU compiler extension so we have to provide our own
          external implementation by default unless we know that our platform is
          using the GNU compiler. *)
-      let default =
-        { cflags = "-DEXTERNAL_EXP10" :: "-std=c99" :: cflags; libs } in
+      let default = { cflags = "-DEXTERNAL_EXP10" :: "-std=c99" :: cflags; libs } in
       Option.value_map (C.ocaml_config_var c "system") ~default ~f:(function
         | "linux" | "linux_elf" -> { cflags = "-std=gnu99" :: cflags; libs }
         | "macosx" when not libs_override ->
@@ -36,4 +35,17 @@ let () =
         | _ -> default)
     in
     C.Flags.write_sexp "c_flags.sexp" conf.cflags;
-    C.Flags.write_sexp "c_library_flags.sexp" conf.libs)
+    C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
+
+    let extra_cflags =
+      (* -march=native is not supported on apple ARM64, its support was introduced
+         in clang >= 15.0.0 *)
+      (* -ffast-math can break IEEE754 floating point semantics, but it is likely
+         safe with the current Lacaml code base *)
+      let default = ["-O3"; "-march=native"; "-ffast-math"; "-fPIC"; "-DPIC"] in
+      Option.value_map (C.ocaml_config_var c "system") ~default ~f:(function
+        | "macosx" when (C.ocaml_config_var c "architecture") = Some "arm64" ->
+            ["-O3"; "-ffast-math"; "-fPIC"; "-DPIC"]
+        | _ -> default)
+    in
+    C.Flags.write_sexp "extra_c_flags.sexp" extra_cflags)

--- a/src/config/dune
+++ b/src/config/dune
@@ -13,7 +13,7 @@
 )
 
 (rule
-  (targets c_flags.sexp c_library_flags.sexp)
+  (targets c_flags.sexp extra_c_flags.sexp c_library_flags.sexp)
   (action (run ./discover.exe)))
 
 (library
@@ -25,10 +25,8 @@
     (flags
       (:standard)
       (:include c_flags.sexp)
-      ; -ffast-math can break IEEE754 floating point semantics, but it is likely
-      ; safe with the current Lacaml code base
-      -O3 -march=native -ffast-math
-      -fPIC -DPIC))
+      (:include extra_c_flags.sexp)
+      ))
   (c_library_flags (:include c_library_flags.sexp) -lm)
 )
 

--- a/src/dune
+++ b/src/dune
@@ -29,10 +29,8 @@
       (:standard)
       (:include config/c_flags.sexp)
       (:include config/blas_kind_flags.sexp)
-      ; -ffast-math can break IEEE754 floating point semantics, but it is likely
-      ; safe with the current Lacaml code base
-      -O3 -march=native -ffast-math
-      -fPIC -DPIC))
+      (:include config/extra_c_flags.sexp)
+      ))
   (c_library_flags (:include config/c_library_flags.sexp) -lm)
 
   (libraries bigarray)


### PR DESCRIPTION
Currently -march=native is not supported by clang, it is going to be introduced in clang 15.0.0. The extra c flags are now also configured dynamically so that -march=native is no longer present on macos on arm64.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>